### PR TITLE
Add improved guess hints (one away)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -140,15 +140,25 @@ function App() {
         setWords(remainingWords);
         setMessage('');
       }, 1000);
-    } else if (categories.length === 2) {
-      // Close! 3 out of 4 correct
-      setMistakes(mistakes + 1);
-      setMessage('One away...');
-      setSelected([]);
     } else {
-      // Wrong guess
+      // Check how many words match each category for better feedback
+      const categoryCounts = {};
+      selectedWords.forEach(w => {
+        categoryCounts[w.category] = (categoryCounts[w.category] || 0) + 1;
+      });
+      
+      const maxMatch = Math.max(...Object.values(categoryCounts));
+      
       setMistakes(mistakes + 1);
-      setMessage('Not quite. Try again!');
+      
+      if (maxMatch === 3) {
+        setMessage('One away...');
+      } else if (maxMatch === 2) {
+        setMessage('Try again!');
+      } else {
+        setMessage('Not quite. Keep trying!');
+      }
+      
       setSelected([]);
     }
   }


### PR DESCRIPTION
## Description
Implements issue #9 - adds helpful hints when users make guesses.

## Changes
- Enhanced hint logic to count matching words per category
- Show **'One away...'** when 3/4 words match a category
- Show **'Try again!'** when 2/4 words match  
- Show **'Not quite. Keep trying!'** for fewer matches
- Provides better user feedback during gameplay, matching the original Connections game behavior

## Testing
- Tested with various guess combinations
- Verified hint messages appear correctly based on match count

Closes #9