### PR TITLE
Fix game state restoration to preserve mistakes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ function App() {
     // Check if we're resuming a saved game
     const isResumingSavedGame = 
       savedState.currentPuzzleIndex === currentPuzzleIndex && 
-      savedState.solved.length > 0;
+      (savedState.solved.length > 0 || savedState.mistakes > 0);
     
     if (isResumingSavedGame) {
       // Restore saved state


### PR DESCRIPTION
## Bug Fix

When reloading the game mid-puzzle, the mistake count was being reset to 0 if no categories had been solved yet.

## Changes
- Update `isResumingSavedGame` condition to check for `mistakes > 0` in addition to `solved.length > 0`
- Now properly restores mistake count when reloading at any point during gameplay

## Issue
Previously the game only considered it a "saved game" if categories had been solved. This meant if you:
1. Made 3 mistakes
2. Haven't solved any categories yet
3. Reload the page

Your mistakes would reset to 0 (guesses remaining back to 4).

## Fix
Now checks for any progress: either solved categories OR mistakes made, so your mistake count persists correctly across page reloads.