### PR TITLE
Fix Docker workflow invalid tag format

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,7 +44,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Bug Fix

Docker builds were failing on PRs with this error:
```
ERROR: failed to build: invalid tag "ghcr.io/slmingol/conjakeions-plus:-5438b58": invalid reference format
```

## Changes
- Remove problematic `prefix={{branch}}-` from the SHA tag type in Docker metadata action
- This was creating invalid tags like `:-5438b58` for PRs (empty branch name with dash)

## Fix
SHA tags will now be formatted correctly as `sha-5438b58` without the branch prefix. Other tags remain unchanged:
- PR tags: `pr-15`
- Branch tags: `main`, `develop`, etc.
- Latest tag: `latest` (main branch only)
- Semver tags: `v1.2.3` when tagged