### PR TITLE
Add unique puzzle stats to stats modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
   const { newVersionAvailable, reload } = useVersionCheck();
   const { stats, recordWin, recordLoss, recordReveal, resetStats, getWinRate, getAverageMistakes } = useStats();
   const { savedState, saveState, clearState } = useGameState();
-  const { recordAttempt, recordCompletion, getPuzzleStats, hasPlayedBefore, hasWonBefore } = usePuzzleHistory();
+  const { recordAttempt, recordCompletion, getPuzzleStats, hasPlayedBefore, hasWonBefore, getTotalPuzzlesAttempted, getTotalPuzzlesWon } = usePuzzleHistory();
   const [currentPuzzleIndex, setCurrentPuzzleIndex] = useState(savedState.currentPuzzleIndex);
   const [puzzleNumberInput, setPuzzleNumberInput] = useState('');
   const [words, setWords] = useState([]);
@@ -468,6 +468,8 @@ function App() {
           stats={stats}
           getWinRate={getWinRate}
           getAverageMistakes={getAverageMistakes}
+          totalPuzzlesAttempted={getTotalPuzzlesAttempted()}
+          totalPuzzlesWon={getTotalPuzzlesWon()}
           onClose={() => setShowStats(false)}
           onReset={() => {
             if (window.confirm('Are you sure you want to reset all statistics? This cannot be undone.')) {

--- a/src/StatsModal.css
+++ b/src/StatsModal.css
@@ -154,6 +154,26 @@
   color: white;
 }
 
+.puzzle-stats-section {
+  padding: 1.5rem;
+  background-color: #f8f9fa;
+  border-top: 1px solid #e0e0e0;
+}
+
+.puzzle-stats-section h3 {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #000;
+  text-align: center;
+}
+
+.puzzle-stats-section .stats-grid {
+  padding: 0;
+  border-bottom: none;
+  grid-template-columns: repeat(2, 1fr);
+}
+
 @media (max-width: 600px) {
   .stats-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/src/StatsModal.jsx
+++ b/src/StatsModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import './StatsModal.css';
 
-function StatsModal({ stats, getWinRate, getAverageMistakes, onClose, onReset }) {
+function StatsModal({ stats, getWinRate, getAverageMistakes, totalPuzzlesAttempted, totalPuzzlesWon, onClose, onReset }) {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
@@ -26,6 +26,20 @@ function StatsModal({ stats, getWinRate, getAverageMistakes, onClose, onReset })
           <div className="stat-item">
             <div className="stat-value">{stats.maxStreak}</div>
             <div className="stat-label">Max Streak</div>
+          </div>
+        </div>
+
+        <div className="puzzle-stats-section">
+          <h3>Unique Puzzles</h3>
+          <div className="stats-grid">
+            <div className="stat-item">
+              <div className="stat-value">{totalPuzzlesAttempted}</div>
+              <div className="stat-label">Attempted</div>
+            </div>
+            <div className="stat-item">
+              <div className="stat-value">{totalPuzzlesWon}</div>
+              <div className="stat-label">Won</div>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Enhancement

Adds tracking of unique puzzles to the stats modal to show overall puzzle progress.

## Changes
- Add new "Unique Puzzles" section to stats modal
- Display total unique puzzles attempted
- Display total unique puzzles won
- Uses existing puzzle history tracking from #13

## UI Updates
- New section with gray background to visually separate from game stats
- Shows two stats in a 2-column grid:
  - **Attempted**: Number of unique puzzles the user has played
  - **Won**: Number of unique puzzles the user has successfully completed

This complements the existing game stats (total games played, win rate, streaks) by showing unique puzzle coverage across the 900+ available puzzles.