### PR TITLE
Fix reset stats to clear puzzle history

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
   const { newVersionAvailable, reload } = useVersionCheck();
   const { stats, recordWin, recordLoss, recordReveal, resetStats, getWinRate, getAverageMistakes } = useStats();
   const { savedState, saveState, clearState } = useGameState();
-  const { recordAttempt, recordCompletion, getPuzzleStats, hasPlayedBefore, hasWonBefore, getTotalPuzzlesAttempted, getTotalPuzzlesWon } = usePuzzleHistory();
+  const { recordAttempt, recordCompletion, getPuzzleStats, hasPlayedBefore, hasWonBefore, getTotalPuzzlesAttempted, getTotalPuzzlesWon, resetHistory } = usePuzzleHistory();
   const [currentPuzzleIndex, setCurrentPuzzleIndex] = useState(savedState.currentPuzzleIndex);
   const [puzzleNumberInput, setPuzzleNumberInput] = useState('');
   const [words, setWords] = useState([]);
@@ -474,6 +474,7 @@ function App() {
           onReset={() => {
             if (window.confirm('Are you sure you want to reset all statistics? This cannot be undone.')) {
               resetStats();
+              resetHistory();
             }
           }}
         />


### PR DESCRIPTION
## Bug Fix

The Reset Statistics button was only clearing general game stats but not the puzzle history stats.

## Changes
- Add `resetHistory()` call to the reset button handler
- Now clears both general game stats AND per-puzzle history when user clicks Reset Statistics

## What gets reset now:
- General stats: games played, wins, losses, streaks, etc.
- Puzzle history: unique puzzles attempted and won (added in #13)

This ensures clicking "Reset Statistics" truly resets all tracked data.