### PR TITLE
Add tag trigger to Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Enhancement

Currently Docker images are only built on push to main/PRs, which means version tags (v2.15.12) don't trigger Docker builds with version-tagged images.

## Changes
- Add `tags: v*.*.*` trigger to Docker build workflow
- Enables the existing `type=semver` metadata action tags
- Will create versioned Docker images in GHCR

## Result
When a version tag is created (v2.15.12), the workflow will now automatically build and push Docker images tagged as:
- `ghcr.io/slmingol/conjakeions-plus:2.15.12`
- `ghcr.io/slmingol/conjakeions-plus:2.15`
- `ghcr.io/slmingol/conjakeions-plus:latest` (if on main)
- `ghcr.io/slmingol/conjakeions-plus:main`

This makes it easy to pin to specific versions in production deployments.