### PR TITLE
Fix reset stats to also clear current game state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -475,6 +475,18 @@ function App() {
             if (window.confirm('Are you sure you want to reset all statistics? This cannot be undone.')) {
               resetStats();
               resetHistory();
+              clearState();
+              // Reset current game state
+              setCurrentPuzzleIndex(0);
+              setMistakes(0);
+              setSolved([]);
+              setSelected([]);
+              setGameOver(false);
+              setMessage('');
+              setRevealed(false);
+              setStatsRecorded(false);
+              setPuzzleAttemptRecorded(false);
+              setShowStats(false);
             }
           }}
         />


### PR DESCRIPTION
## Bug Fix

When clicking Reset Statistics, the historical stats were cleared but the current in-progress game state remained (showing mistakes, solved categories, etc.).

## Changes
- Add `clearState()` call to clear saved game state from localStorage
- Reset current puzzle to #1
- Clear mistakes back to 0
- Clear solved categories and selections
- Reset game over state and messages
- Close stats modal after reset

## Result
Clicking "Reset Statistics" now truly resets everything:
- ✅ Historical stats (games played, wins, losses, etc.)
- ✅ Puzzle history (unique puzzles attempted/won)
- ✅ Current game state (mistakes, solved categories, current puzzle)

The game will start fresh on puzzle #1 with 0 mistakes.